### PR TITLE
Add optional map output for straight roads

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
 # straigt
-Find straight roads
+
+Find straight roads and optionally visualise them on an interactive map.
+
+## Usage
+
+```
+python find_straight_ways.py pbf/saarland-latest.osm.pbf \
+    --min-length 1000 --min-straightness 0.99 --map result.html
+```
+
+The `--map` option writes an HTML file with the found ways drawn using
+[Folium](https://python-visualization.github.io/folium/). Install the
+dependency with `pip install folium` if it is not already available.


### PR DESCRIPTION
## Summary
- support exporting straight way results to an interactive HTML map using Folium
- track full way geometry for map rendering
- document new `--map` option in README

## Testing
- `python find_straight_ways.py pbf/saarland-latest.osm.pbf --min-length 1000 --min-straightness 0.99 --top 2 --map map.html`

------
https://chatgpt.com/codex/tasks/task_e_68a0d9b29e548327a77f9726aba89aba