### PR TITLE
Implement graph-based merging with angle and tag filters

### DIFF
--- a/find_straight_ways_v02.py
+++ b/find_straight_ways_v02.py
@@ -4,8 +4,10 @@
 This V02 script joins adjacent road segments before measuring their length
 and straightness. It considers ways tagged as ``highway=track``,
 ``highway=service`` or ``highway=unclassified`` and merges directly connected
-segments with the same ``highway`` and ``name`` (if present). The straightness
-of each merged run is calculated as the ratio between the geodesic distance of
+segments with the same ``highway`` and ``name`` (if present). The merging uses
+a graph search that respects a configurable maximum angular deviation and can
+optionally filter by ``oneway`` or ``access`` tags. The straightness of each
+merged run is calculated as the ratio between the geodesic distance of
 its end points and the actual path length.
 
 Example:
@@ -18,7 +20,8 @@ from __future__ import annotations
 import argparse
 import json
 from collections import defaultdict
-from typing import Dict, List, Tuple
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Tuple
 
 import osmium
 import pyproj
@@ -29,15 +32,31 @@ except Exception:  # pragma: no cover - optional dependency
     folium = None
 
 
-RelevantWay = Dict[str, object]
+@dataclass
+class SegmentInfo:
+    """Information about a single OSM way segment."""
+
+    id: int
+    nodes: List[int]
+    geometry: List[List[float]]
+    highway: str
+    name: Optional[str]
+    oneway: Optional[str]
+    access: Optional[str]
 
 
 class WayCollector(osmium.SimpleHandler):
-    """Collect relevant OSM ways grouped by (highway, name)."""
+    """Collect relevant OSM ways grouped by (highway, name) with graph edges."""
 
-    def __init__(self) -> None:
+    def __init__(
+        self, oneway_filter: str | None = None, access_filter: str | None = None
+    ) -> None:
         super().__init__()
-        self.groups: Dict[Tuple[str, str | None], List[RelevantWay]] = defaultdict(list)
+        self.oneway_filter = oneway_filter
+        self.access_filter = access_filter
+        self.groups: Dict[
+            Tuple[str, str | None], Dict[str, object]
+        ] = defaultdict(lambda: {"segments": [], "node_neighbors": defaultdict(list)})
 
     def way(self, w: osmium.osm.Way) -> None:  # type: ignore[override]
         highway = w.tags.get("highway")
@@ -46,76 +65,136 @@ class WayCollector(osmium.SimpleHandler):
         if len(w.nodes) < 2:
             return
         name = w.tags.get("name")
+        oneway = w.tags.get("oneway")
+        access = w.tags.get("access")
+        if self.oneway_filter is not None and oneway != self.oneway_filter:
+            return
+        if self.access_filter is not None and access != self.access_filter:
+            return
         lats = [n.lat for n in w.nodes]
         lons = [n.lon for n in w.nodes]
         nodes = [n.ref for n in w.nodes]
         geometry: List[List[float]] = [[lat, lon] for lat, lon in zip(lats, lons)]
-        self.groups[(highway, name)].append(
-            {"id": w.id, "nodes": nodes, "geometry": geometry}
+
+        segment = SegmentInfo(
+            id=w.id,
+            nodes=nodes,
+            geometry=geometry,
+            highway=highway,
+            name=name,
+            oneway=oneway,
+            access=access,
         )
+        group = self.groups[(highway, name)]
+        group["segments"].append(segment)
+        group["node_neighbors"][nodes[0]].append(segment)
+        group["node_neighbors"][nodes[-1]].append(segment)
 
 
 def merge_segments(
-    segments: List[RelevantWay], geod: pyproj.Geod, min_len: float, min_ratio: float
+    segments: List[SegmentInfo],
+    node_neighbors: Dict[int, List[SegmentInfo]],
+    geod: pyproj.Geod,
+    min_len: float,
+    min_ratio: float,
+    max_angle: float,
 ) -> List[Dict[str, object]]:
-    """Merge connected segments into longer runs and calculate metrics."""
+    """Merge connected segments into longer runs using a graph search."""
 
-    node_to_segments: Dict[int, List[int]] = defaultdict(list)
-    for idx, seg in enumerate(segments):
-        nodes = seg["nodes"]  # type: ignore[index]
-        node_to_segments[nodes[0]].append(idx)
-        node_to_segments[nodes[-1]].append(idx)
+    def direction_allowed(seg: SegmentInfo, from_node: int) -> bool:
+        oneway = seg.oneway
+        if not oneway or oneway.lower() in {"no", "0", "false"}:
+            return True
+        if oneway in {"-1", "reverse"}:
+            return from_node == seg.nodes[-1]
+        return from_node == seg.nodes[0]
+
+    def extend_path(
+        node: int,
+        prev_az: float,
+        ids: List[int],
+        geometry: List[List[float]],
+        insert_front: bool,
+        base_oneway: Optional[str],
+        base_access: Optional[str],
+    ) -> Tuple[int, List[int], List[List[float]], float]:
+        cur_node = node
+        azimuth = prev_az
+        while True:
+            neighbors = [s for s in node_neighbors[cur_node] if s.id not in visited]
+            valid: List[Tuple[SegmentInfo, int, float, bool]] = []
+            for cand in neighbors:
+                if cand.oneway != base_oneway or cand.access != base_access:
+                    continue
+                if cur_node == cand.nodes[0]:
+                    if not direction_allowed(cand, cand.nodes[0]):
+                        continue
+                    next_node = cand.nodes[-1]
+                    cand_az = geod.inv(
+                        cand.geometry[0][1],
+                        cand.geometry[0][0],
+                        cand.geometry[1][1],
+                        cand.geometry[1][0],
+                    )[0]
+                    forward = True
+                else:
+                    if not direction_allowed(cand, cand.nodes[-1]):
+                        continue
+                    next_node = cand.nodes[0]
+                    cand_az = geod.inv(
+                        cand.geometry[-1][1],
+                        cand.geometry[-1][0],
+                        cand.geometry[-2][1],
+                        cand.geometry[-2][0],
+                    )[0]
+                    forward = False
+                diff = abs((cand_az - azimuth + 180) % 360 - 180)
+                if diff <= max_angle:
+                    valid.append((cand, next_node, cand_az, forward))
+            if len(valid) != 1:
+                break
+            cand, next_node, cand_az, forward = valid[0]
+            visited.add(cand.id)
+            if insert_front:
+                ids.insert(0, cand.id)
+                if forward:
+                    geometry = cand.geometry[:-1] + geometry
+                else:
+                    geometry = cand.geometry[1:][::-1] + geometry
+            else:
+                ids.append(cand.id)
+                if forward:
+                    geometry.extend(cand.geometry[1:])
+                else:
+                    geometry.extend(cand.geometry[-2::-1])
+            cur_node = next_node
+            azimuth = cand_az
+        return cur_node, ids, geometry, azimuth
 
     visited: set[int] = set()
     candidates: List[Dict[str, object]] = []
 
-    for i, seg in enumerate(segments):
-        if i in visited:
+    for seg in segments:
+        if seg.id in visited:
             continue
-        visited.add(i)
-        nodes = seg["nodes"]  # type: ignore[index]
-        geometry = seg["geometry"][:]  # type: ignore[index]
-        ids = [seg["id"]]  # type: ignore[index]
-        start = nodes[0]
-        end = nodes[-1]
+        visited.add(seg.id)
+        ids = [seg.id]
+        geometry = seg.geometry[:]
+        start = seg.nodes[0]
+        end = seg.nodes[-1]
 
-        # extend forward from end
-        cur = end
-        while True:
-            next_idxs = [idx for idx in node_to_segments[cur] if idx not in visited]
-            if len(next_idxs) != 1:
-                break
-            nxt = segments[next_idxs[0]]
-            visited.add(next_idxs[0])
-            ids.append(nxt["id"])  # type: ignore[index]
-            nxt_nodes = nxt["nodes"]  # type: ignore[index]
-            nxt_geom = nxt["geometry"]  # type: ignore[index]
-            if nxt_nodes[0] == cur:
-                geometry.extend(nxt_geom[1:])
-                cur = nxt_nodes[-1]
-            else:
-                geometry.extend(nxt_geom[-2::-1])
-                cur = nxt_nodes[0]
-        end = cur
-
-        # extend backward from start
-        cur = start
-        while True:
-            next_idxs = [idx for idx in node_to_segments[cur] if idx not in visited]
-            if len(next_idxs) != 1:
-                break
-            nxt = segments[next_idxs[0]]
-            visited.add(next_idxs[0])
-            ids.insert(0, nxt["id"])  # type: ignore[index]
-            nxt_nodes = nxt["nodes"]  # type: ignore[index]
-            nxt_geom = nxt["geometry"]  # type: ignore[index]
-            if nxt_nodes[-1] == cur:
-                geometry = nxt_geom[:-1] + geometry
-                cur = nxt_nodes[0]
-            else:
-                geometry = nxt_geom[1:][::-1] + geometry
-                cur = nxt_nodes[-1]
-        start = cur
+        az = geod.inv(
+            geometry[-2][1], geometry[-2][0], geometry[-1][1], geometry[-1][0]
+        )[0]
+        end, ids, geometry, az = extend_path(
+            end, az, ids, geometry, False, seg.oneway, seg.access
+        )
+        az = geod.inv(
+            geometry[1][1], geometry[1][0], geometry[0][1], geometry[0][0]
+        )[0]
+        start, ids, geometry, _ = extend_path(
+            start, az, ids, geometry, True, seg.oneway, seg.access
+        )
 
         length = 0.0
         for j in range(len(geometry) - 1):
@@ -157,6 +236,12 @@ def main() -> None:
         help="Minimum straightness ratio (default: 0.99)",
     )
     parser.add_argument(
+        "--max-angle",
+        type=float,
+        default=10.0,
+        help="Maximum allowed deviation angle in degrees between consecutive segments (default: 10)",
+    )
+    parser.add_argument(
         "--top",
         type=int,
         default=5,
@@ -174,15 +259,36 @@ def main() -> None:
         default=None,
         help="Optional path to write an interactive HTML map",
     )
+    parser.add_argument(
+        "--oneway",
+        type=str,
+        default=None,
+        help="Filter ways by oneway tag value",
+    )
+    parser.add_argument(
+        "--access",
+        type=str,
+        default=None,
+        help="Filter ways by access tag value",
+    )
     args = parser.parse_args()
 
     geod = pyproj.Geod(ellps="WGS84")
-    collector = WayCollector()
+    collector = WayCollector(args.oneway, args.access)
     collector.apply_file(args.pbf, locations=True)
 
     candidates: List[Dict[str, object]] = []
-    for (highway, name), segs in collector.groups.items():
-        merged = merge_segments(segs, geod, args.min_length, args.min_straightness)
+    for (highway, name), data in collector.groups.items():
+        segs = data["segments"]
+        neighbors = data["node_neighbors"]
+        merged = merge_segments(
+            segs,
+            neighbors,
+            geod,
+            args.min_length,
+            args.min_straightness,
+            args.max_angle,
+        )
         for c in merged:
             c["highway"] = highway
             if name:


### PR DESCRIPTION
## Summary
- Build graph of relevant OSM ways storing segments per node
- Replace linear chain merging with graph-based search respecting angle and tag compatibility
- Expose CLI options for maximum angle deviation and oneway/access filters

## Testing
- `python -m py_compile find_straight_ways_v02.py`
- `python find_straight_ways_v02.py --help`

------
https://chatgpt.com/codex/tasks/task_e_68a0ef3b1f3c8327918789c55e8126cd