### PR TITLE
Consider all highway tags

### DIFF
--- a/find_straight_ways.py
+++ b/find_straight_ways.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
 """Find long, straight ways in an OSM PBF file.
 
-The script scans an OSM PBF file for ways tagged as `highway=track`,
-`highway=service` or `highway=unclassified` and measures their length and
-straightness (ratio of the geodesic distance between start and end node to the
-actual path length). Ways that exceed the given thresholds are reported.
+The script scans an OSM PBF file for ways tagged with ``highway=*`` and measures
+their length and straightness (ratio of the geodesic distance between start and
+end node to the actual path length). Ways that exceed the given thresholds are
+reported.
 
 Example:
     python find_straight_ways.py pbf/saarland-latest.osm.pbf --min-length 1000 --min-straightness 0.99
@@ -35,9 +35,7 @@ class StraightWayHandler(osmium.SimpleHandler):
 
     def way(self, w: osmium.osm.Way) -> None:  # type: ignore[override]
         highway = w.tags.get("highway")
-        if highway not in {"track", "service", "unclassified"}:
-            return
-        if len(w.nodes) < 2:
+        if highway is None or len(w.nodes) < 2:
             return
 
         lats = [n.lat for n in w.nodes]

--- a/find_straight_ways_v02.py
+++ b/find_straight_ways_v02.py
@@ -2,13 +2,12 @@
 """Find long, straight road runs in an OSM PBF file.
 
 This V02 script joins adjacent road segments before measuring their length
-and straightness. It considers ways tagged as ``highway=track``,
-``highway=service`` or ``highway=unclassified`` and merges directly connected
-segments with the same ``highway`` and ``name`` (if present). The merging uses
-a graph search that respects a configurable maximum angular deviation and can
-optionally filter by ``oneway`` or ``access`` tags. The straightness of each
-merged run is calculated as the ratio between the geodesic distance of
-its end points and the actual path length.
+and straightness. It considers all ways tagged with ``highway=*`` and merges
+directly connected segments with the same ``highway`` and ``name`` (if present).
+The merging uses a graph search that respects a configurable maximum angular
+deviation and can optionally filter by ``oneway`` or ``access`` tags. The
+straightness of each merged run is calculated as the ratio between the geodesic
+distance of its end points and the actual path length.
 
 Example:
     python find_straight_ways_v02.py pbf/saarland-latest.osm.pbf \
@@ -60,9 +59,7 @@ class WayCollector(osmium.SimpleHandler):
 
     def way(self, w: osmium.osm.Way) -> None:  # type: ignore[override]
         highway = w.tags.get("highway")
-        if highway not in {"track", "service", "unclassified"}:
-            return
-        if len(w.nodes) < 2:
+        if highway is None or len(w.nodes) < 2:
             return
         name = w.tags.get("name")
         oneway = w.tags.get("oneway")


### PR DESCRIPTION
## Summary
- Allow scripts to analyze all OSM highways by removing specific tag restrictions
- Update documentation to describe support for any `highway=*` tag

## Testing
- `python find_straight_ways.py -h`
- `python find_straight_ways_v02.py -h`


------
https://chatgpt.com/codex/tasks/task_e_68a184ef313c8327ae6e9f0bdad3c6dc